### PR TITLE
Add devpi-client to packages installed into the docker image

### DIFF
--- a/.github/workflows/XmsInterp-CI.yaml
+++ b/.github/workflows/XmsInterp-CI.yaml
@@ -183,7 +183,7 @@ jobs:
       CONAN_BUILD_TYPES: ${{ matrix.build_type }}
       CONAN_GCC_VERSIONS: ${{ matrix.compiler-version }}
       CONAN_DOCKER_IMAGE: docker.aquaveo.com/aquaveo/conan-docker/conan-gcc${{ matrix.compiler-version }}-py${{ matrix.python-version }}:latest
-      CONAN_PIP_INSTALL: 'conan-package-tools==0.35.1 numpy==1.26.4'
+      CONAN_PIP_INSTALL: 'conan-package-tools==0.35.1 numpy==1.26.4 devpi-client'
       CONAN_PIP_PACKAGE: 'conan==1.60.0'
       # The gcc docker image (mutable :latest tag) was rebuilt to a pyenv-based
       # Python: pip now lives at /opt/pyenv/shims/pip, on the default user's PATH


### PR DESCRIPTION
The tagging step needs `devpi-client` installed, which is no longer preinstalled in the Docker image. Make the CI install it explicitly so it can tag.