### PR TITLE
Remove numpy pin from conan1 setup.py

### DIFF
--- a/_package/setup.py
+++ b/_package/setup.py
@@ -10,7 +10,7 @@ from xms.interp import __version__
 os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 
 requires = [
-    'numpy<2.0.0',
+    'numpy',
     'xmscore>=6.0.0',
     'xmsgrid>=7.0.0, <8.0.0',
 ]

--- a/_package/xms/interp/__init__.py
+++ b/_package/xms/interp/__init__.py
@@ -3,4 +3,4 @@ from . import interpolate  # NOQA: F401
 from .api.interpolator import interpolate_to_grid  # NOQA: F401
 from .api.interpolator import interpolate_to_points  # NOQA: F401
 
-__version__ = '6.1.9'
+__version__ = '6.1.10'


### PR DESCRIPTION
This pull request makes a minor update to the package dependencies and versioning. The main changes are:

Dependency updates:

* The `numpy` version constraint was relaxed in `setup.py`, allowing installation of any version of `numpy` rather than restricting to versions below 2.0.0.

Version bump:

* The package version was updated from `6.1.9` to `6.1.10` in `__init__.py` to reflect the latest changes.