### PR TITLE
Bump xmscore/xmsgrid and regenerate CI with xmsconan 2.18.0

### DIFF
--- a/.github/workflows/XmsInterp-CI.yaml
+++ b/.github/workflows/XmsInterp-CI.yaml
@@ -42,7 +42,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install flake8 flake8-docstrings flake8-bugbear flake8-import-order pep8-naming
-          pip install "xmsconan==2.16.0" -i https://public.aquapi.aquaveo.com/aquaveo/dev/+simple
+          pip install --upgrade "xmsconan>=2.18.0" -i https://public.aquapi.aquaveo.com/aquaveo/dev/+simple
       # Generate .flake8 so CI lints with the same config developers use locally.
       # Do not inline the flake8 settings here: that duplicates .flake8.jinja and
       # the two copies drift apart silently.
@@ -113,7 +113,7 @@ jobs:
           # package_id computation and silently detach builds from the binaries
           # already published to the remote. Bump this deliberately.
           pip install "conan~=2.31.0" devpi-client wheel
-          python -m pip install --upgrade "xmsconan==2.16.0" -i https://public.aquapi.aquaveo.com/aquaveo/dev/+simple
+          python -m pip install --upgrade "xmsconan>=2.18.0" -i https://public.aquapi.aquaveo.com/aquaveo/dev/+simple
       # Setup Conan
       - name: Setup Conan
         run: xmsconan_conan_setup --remote-url ${{ env.CONAN_REMOTE_URL }} --login --remove-conancenter
@@ -250,7 +250,7 @@ jobs:
           # package_id computation and silently detach builds from the binaries
           # already published to the remote. Bump this deliberately.
           pip install "conan~=2.31.0" devpi-client wheel
-          pip install --upgrade "xmsconan==2.16.0" -i https://public.aquapi.aquaveo.com/aquaveo/dev/+simple
+          pip install --upgrade "xmsconan>=2.18.0" -i https://public.aquapi.aquaveo.com/aquaveo/dev/+simple
       # Setup Conan
       - name: Setup Conan
         run: xmsconan_conan_setup --remote-url ${{ env.CONAN_REMOTE_URL }} --login
@@ -398,7 +398,7 @@ jobs:
           # package_id computation and silently detach builds from the binaries
           # already published to the remote. Bump this deliberately.
           pip install "conan~=2.31.0" devpi-client wheel
-          python -m pip install --upgrade "xmsconan==2.16.0" -i https://public.aquapi.aquaveo.com/aquaveo/dev/+simple
+          python -m pip install --upgrade "xmsconan>=2.18.0" -i https://public.aquapi.aquaveo.com/aquaveo/dev/+simple
       # Setup Visual Studio
       - name: Setup Visual Studio
         uses: microsoft/setup-msbuild@v2

--- a/build.toml
+++ b/build.toml
@@ -3,8 +3,8 @@ description = "Interpolation library for XMS products"
 ci_type = "github"
 
 xms_dependencies = [
-    { name = "xmscore", version = "7.0.11" },
-    { name = "xmsgrid", version = "9.0.10" },
+    { name = "xmscore", version = "7.0.12" },
+    { name = "xmsgrid", version = "9.0.11" },
 ]
 
 python_namespaced_dir = "interp"


### PR DESCRIPTION
Third library onto the VS2019 bridge, after [xmscore 7.0.12](https://github.com/Aquaveo/xmscore/releases/tag/7.0.12) and [xmsgrid 9.0.11](https://github.com/Aquaveo/xmsgrid/releases/tag/9.0.11). Six lines, two coupled changes.

## 1. Dependency bumps — required, not routine

| dependency | from | to |
|---|---|---|
| xmscore | 7.0.11 | **7.0.12** |
| xmsgrid | 9.0.10 | **9.0.11** |

`xms_dependencies` pins **exact** versions, and **neither 7.0.11 nor 9.0.10 was ever built for msvc 192**. Only 7.0.12 and 9.0.11 exist on `aquaveo-vs2019`, so left at the old pins the VS2019 build of xmsinterp fails at graph resolution before compiling a single file.

Both bumps are inert for the VS2022 side. Each of those releases contained only its own dependency-and-CI bump — no C++ source change — and each is published on both remotes at a single matching recipe revision (`xmscore c58afa49…`, `xmsgrid 66ac6991…`).

## 2. xmsconan `==2.16.0` → `>=2.18.0`

CI must generate the recipe with the same xmsconan the manual VS2019 track uses. `XmsConan2File.export()` copies `xms_conan2_file.py` into the export folder, so its contents feed the **recipe revision hash**, and 2.18.0 changes that file by 192 lines (the msvc 192 fork). Generating with 2.16.0 in CI and 2.18.0 locally would publish **different rrevs for the same version**.

## Blast radius on the VS2022 side: none

- CI diff is **pins only** — verified by filtering the diff for non-xmsconan changes.
- No `[vs2019_dependency_overrides]` table, so the generated `conanfile.py` gains no new attribute.
- Regenerated recipe verified: `xms_dependencies = ["xmscore/7.0.12", "xmsgrid/9.0.11"]`, `testing_framework = "cxxtest"` (relevant because `gtest/1.17.0` has no msvc 192 build).

## Last regeneration commit

2.17.0 floated generated CI onto `>=` with `--upgrade`, so future xmsconan releases arrive on the next CI run. The flake job picks up `--upgrade`, which it lacked under the `==` pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)